### PR TITLE
fix: partial signing not correctly appending

### DIFF
--- a/gateway.php
+++ b/gateway.php
@@ -445,7 +445,7 @@ class Gateway {
 
 		// Mark as partially signed if required
 		if ($partial) {
-			$ret . '|' . $partial;
+			$ret .= '|' . $partial;
 		}
 
 		return $ret;


### PR DESCRIPTION
When using the Hosted Gateway we were getting a 66343 error due to an invalid signature as the return value from sign() didn't correctly amend the partial fields (using PHP 7.4)